### PR TITLE
Match all Poll messages received by consumer actor when unsubscribed

### DIFF
--- a/akka/src/main/scala/cakesolutions/kafka/akka/KafkaConsumerActor.scala
+++ b/akka/src/main/scala/cakesolutions/kafka/akka/KafkaConsumerActor.scala
@@ -220,11 +220,9 @@ private class KafkaConsumerActor[K: TypeTag, V: TypeTag](
       become(ready)
       pollImmediate(delayedPollTimeout)
 
-    case poll: Poll if !isCurrentPoll(poll) =>
+    case _: Poll =>
       // Do nothing
 
-    // TODO: What about a poll that is current? The next one could have been placed in our mailbox after the
-    // unsubscribe and before we cancelled the scheduler
   }
 
   private def subscribe(offsets: Option[Offsets]): Unit = {


### PR DESCRIPTION
I never observed a Poll message go to dead letters, but if I understood things
correctly, in rare cases they could have done.