### PR TITLE
Add perf test for e2e scenario

### DIFF
--- a/akka/src/it/scala/cakesolutions/kafka/akka/KafkaConsumerActorPerfSpec.scala
+++ b/akka/src/it/scala/cakesolutions/kafka/akka/KafkaConsumerActorPerfSpec.scala
@@ -108,7 +108,7 @@ class ReceiverPilot(expectedMessages: Long) extends TestActor.AutoPilot {
         sender ! Confirm(r.offsets)
         if (total >= expectedMessages) {
           val totalTime = System.currentTimeMillis() - start
-          val messagesPerSec = expectedMessages / totalTime * 100
+          val messagesPerSec = expectedMessages / totalTime * 1000
           finished.success((totalTime, messagesPerSec))
           TestActor.NoAutoPilot
         } else {

--- a/akka/src/it/scala/cakesolutions/kafka/akka/KafkaE2EActorPerfSpec.scala
+++ b/akka/src/it/scala/cakesolutions/kafka/akka/KafkaE2EActorPerfSpec.scala
@@ -1,0 +1,134 @@
+package cakesolutions.kafka.akka
+
+import akka.actor.{ActorRef, ActorSystem}
+import akka.testkit.TestActor.AutoPilot
+import akka.testkit.{ImplicitSender, TestActor, TestKit, TestProbe}
+import cakesolutions.kafka.akka.KafkaConsumerActor.{Confirm, Subscribe, Unsubscribe}
+import cakesolutions.kafka.testkit.TestUtils
+import cakesolutions.kafka.{KafkaConsumer, KafkaProducer, KafkaProducerRecord}
+import com.typesafe.config.ConfigFactory
+import org.apache.kafka.common.serialization.{StringDeserializer, StringSerializer}
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.{Millis, Seconds, Span}
+import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
+import org.slf4j.LoggerFactory
+
+import scala.concurrent.Promise
+
+/**
+  * Ad hoc performance test for validating async consumer performance.  Pass environment variable KAFKA with contact point for
+  * Kafka server e.g. -DKAFKA=127.0.0.1:9092
+  */
+class KafkaE2EActorPerfSpec(system_ : ActorSystem)
+  extends TestKit(system_)
+    with ImplicitSender
+    with FlatSpecLike
+    with Matchers
+    with BeforeAndAfterAll
+    with ScalaFutures {
+
+  val log = LoggerFactory.getLogger(getClass)
+
+  def this() = this(ActorSystem("MySpec"))
+
+  override def afterAll() {
+    TestKit.shutdownActorSystem(system)
+  }
+
+  override implicit val patienceConfig = PatienceConfig(Span(10L, Seconds), Span(100L, Millis))
+
+  val config = ConfigFactory.load()
+
+  val msg1k = scala.io.Source.fromInputStream(getClass.getResourceAsStream("/1k.txt")).mkString
+
+  val consumerConf: KafkaConsumer.Conf[String, String] = {
+    KafkaConsumer.Conf(config.getConfig("consumer"),
+      new StringDeserializer,
+      new StringDeserializer
+    )
+  }
+
+  def consumerActorConf(topic: String): KafkaConsumerActor.Conf = {
+    KafkaConsumerActor.Conf(List(topic)).withConf(config.getConfig("consumer"))
+  }
+
+  val producerConf = KafkaProducer.Conf(config.getConfig("producer"), new StringSerializer, new StringSerializer)
+
+  "KafkaConsumerActor to KafkaProducer with async commit" should "perform" in {
+    val sourceTopic = TestUtils.randomString(5)
+    val targetTopic = TestUtils.randomString(5)
+    val totalMessages = 100000
+
+    //For loading the source topic with test data
+    val testProducer = KafkaProducer[String, String](producerConf)
+
+    val producer = system.actorOf(KafkaProducerActor.props(producerConf))
+
+    val pilot = new PipelinePilot(producer, targetTopic, totalMessages)
+    val receiver = TestProbe()
+    receiver.setAutoPilot(pilot)
+
+    val consumer = system.actorOf(KafkaConsumerActor.props(consumerConf, consumerActorConf(sourceTopic), receiver.ref))
+
+    1 to totalMessages foreach { n =>
+      testProducer.send(KafkaProducerRecord(sourceTopic, None, msg1k))
+    }
+    testProducer.flush()
+    log.info("Delivered {} messages to topic {}", totalMessages, sourceTopic)
+
+    consumer ! Subscribe()
+
+    whenReady(pilot.future) { case (totalTime, messagesPerSec) =>
+      log.info("Total Time millis : {}", totalTime)
+      log.info("Messages per sec  : {}", messagesPerSec)
+
+      totalTime should be < 7000L
+
+      consumer ! Unsubscribe
+      testProducer.close()
+      log.info("Done")
+    }
+  }
+}
+
+class PipelinePilot(producer: ActorRef, targetTopic: String, expectedMessages: Long) extends TestActor.AutoPilot {
+
+  private val log = LoggerFactory.getLogger(getClass)
+
+  private var total = 0
+  private var start = 0l
+
+  private val finished = Promise[(Long, Long)]()
+
+  def future = finished.future
+
+  val matcher = ConsumerRecords.extractor[String, String]
+
+  override def run(sender: ActorRef, msg: Any): AutoPilot = {
+
+    if (total == 0)
+      start = System.currentTimeMillis()
+
+    matcher.unapply(msg) match {
+      case Some(r) =>
+        total += r.size
+
+        producer.!(
+          ProducerRecords(r.toProducerRecords(targetTopic), Some(Confirm(r.offsets, commit = true)))
+        )(sender)
+
+        if (total >= expectedMessages) {
+          val totalTime = System.currentTimeMillis() - start
+          val messagesPerSec = expectedMessages / totalTime * 100
+          finished.success((totalTime, messagesPerSec))
+          TestActor.NoAutoPilot
+        } else {
+          TestActor.KeepRunning
+        }
+
+      case None =>
+        log.warn("Received unknown messages!")
+        TestActor.KeepRunning
+    }
+  }
+}

--- a/akka/src/it/scala/cakesolutions/kafka/akka/KafkaE2EActorPerfSpec.scala
+++ b/akka/src/it/scala/cakesolutions/kafka/akka/KafkaE2EActorPerfSpec.scala
@@ -119,7 +119,7 @@ class PipelinePilot(producer: ActorRef, targetTopic: String, expectedMessages: L
 
         if (total >= expectedMessages) {
           val totalTime = System.currentTimeMillis() - start
-          val messagesPerSec = expectedMessages / totalTime * 100
+          val messagesPerSec = expectedMessages / totalTime * 1000
           finished.success((totalTime, messagesPerSec))
           TestActor.NoAutoPilot
         } else {

--- a/akka/src/main/scala/cakesolutions/kafka/akka/KafkaProducerActor.scala
+++ b/akka/src/main/scala/cakesolutions/kafka/akka/KafkaProducerActor.scala
@@ -13,15 +13,14 @@ import scala.util.{Failure, Success}
 /**
   * An actor that wraps [[KafkaProducer]].
   *
-  * The actor takes incoming (batches of) Kafka records, writes them to Kafka,
-  * and replies to sender once the messages have been written.
+  * The actor takes incoming (batches of) Kafka records, writes them to Kafka, and optionally replies to the sender
+  * once the message are confirmed to be written to Kafka.  The optional response message can be used to facilitate a
+  * commit to an upstream source, for example.
   *
-  * [[KafkaProducerActor]] is not tied to any specific topic,
-  * but its message serializers have to be specified before it's used.
+  * [[KafkaProducerActor]] is not tied to any specific topic, but its message serializers have to be specified before it's used.
   *
   * The types of messages that [[KafkaProducerActor]] consumes is controlled by a [[KafkaProducerActor.Matcher]].
-  * By default, the actor accepts all [[ProducerRecords]] messages which have key and value types
-  * matching the producer actor's type parameters.
+  * By default, the actor accepts all [[ProducerRecords]] messages which have key and value types matching the producer actor's type parameters.
   */
 object KafkaProducerActor {
 
@@ -109,13 +108,11 @@ object KafkaProducerActor {
   }
 }
 
-private class KafkaProducerActor[K, V](
-  producerConf: KafkaProducer.Conf[K, V],
-  matcher: KafkaProducerActor.Matcher[K, V])
+private class KafkaProducerActor[K, V](producerConf: KafkaProducer.Conf[K, V], matcher: KafkaProducerActor.Matcher[K, V])
   extends Actor with ActorLogging {
 
-  import context.dispatcher
   import KafkaProducerActor.MatcherResult
+  import context.dispatcher
 
   type Record = ProducerRecord[K, V]
   type Records = Iterable[Record]

--- a/akka/src/main/scala/cakesolutions/kafka/akka/ProducerRecords.scala
+++ b/akka/src/main/scala/cakesolutions/kafka/akka/ProducerRecords.scala
@@ -137,7 +137,7 @@ object ProducerRecords {
   */
 case class ProducerRecords[Key: TypeTag, Value: TypeTag](
   records: Iterable[ProducerRecord[Key, Value]],
-  response: Option[Any]) {
+  response: Option[Any] = None) {
 
   val keyTag: TypeTag[Key] = typeTag[Key]
   val valueTag: TypeTag[Value] = typeTag[Value]

--- a/akka/src/test/scala/cakesolutions/kafka/akka/KafkaConsumerActorSpec.scala
+++ b/akka/src/test/scala/cakesolutions/kafka/akka/KafkaConsumerActorSpec.scala
@@ -101,7 +101,7 @@ class KafkaConsumerActorSpec(system_ : ActorSystem) extends KafkaIntSpec(system_
         """.stripMargin)
   }
 
-  "KafkaConsumerActors with different configuration types" should "consume a message successfully" in {
+  "KafkaConsumerActors with different configuration types" should "each consume a message successfully" in {
 
     (List(consumerConfFromConfig, consumerConf) zip List(actorConf(TestUtils.randomString(5)), actorConfFromConfig(TestUtils.randomString(5)), actorConfFromMinimalConfig(TestUtils.randomString(5))))
       .foreach {
@@ -140,8 +140,4 @@ class KafkaConsumerActorSpec(system_ : ActorSystem) extends KafkaIntSpec(system_
     consumer ! Unsubscribe
     producer.close()
   }
-
-  //TODO changing actor config settings - timeout etc
-
-  //TODO test message pattern
 }

--- a/akka/src/test/scala/cakesolutions/kafka/akka/KafkaIntSpec.scala
+++ b/akka/src/test/scala/cakesolutions/kafka/akka/KafkaIntSpec.scala
@@ -6,6 +6,9 @@ import cakesolutions.kafka.testkit.KafkaServer
 import org.scalatest.concurrent.AsyncAssertions
 import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
 
+/**
+  * ScalaTest base class for scala-kafka-client-testkit based integration tests
+  */
 class KafkaIntSpec(system: ActorSystem) extends TestKit(system)
   with ImplicitSender
   with AsyncAssertions

--- a/akka/src/test/scala/cakesolutions/kafka/akka/KafkaProducerActorSpec.scala
+++ b/akka/src/test/scala/cakesolutions/kafka/akka/KafkaProducerActorSpec.scala
@@ -28,7 +28,7 @@ class KafkaProducerActorSpec(system_ : ActorSystem) extends KafkaIntSpec(system_
   val serializer = new StringSerializer
   val producerConf = KafkaProducer.Conf(serializer, serializer, bootstrapServers = s"localhost:$kafkaPort")
 
-  "KafkaProducerActor" should "write given batch to Kafka" in {
+  "KafkaProducerActor" should "write a given batch to Kafka" in {
     val topic = "sometopic"
     val probe = TestProbe()
     val producer = system.actorOf(KafkaProducerActor.props(producerConf))
@@ -41,6 +41,29 @@ class KafkaProducerActorSpec(system_ : ActorSystem) extends KafkaIntSpec(system_
     probe.send(producer, message)
 
     probe.expectMsg('response)
+
+    val results = consumeFromTopic(topic, 3, 10000)
+
+    results(0) shouldEqual (None, "foo")
+    results(1) shouldEqual (Some("key"), "value")
+    results(2) shouldEqual (None, "bar")
+  }
+
+  "KafkaProducerActor" should "write a given batch to Kafka, requiring no response" in {
+    import scala.concurrent.duration._
+
+    val topic = "sometopic"
+    val probe = TestProbe()
+    val producer = system.actorOf(KafkaProducerActor.props(producerConf))
+    val batch: Seq[ProducerRecord[String, String]] = Seq(
+      KafkaProducerRecord(topic, "foo"),
+      KafkaProducerRecord(topic, "key", "value"),
+      KafkaProducerRecord(topic, "bar"))
+    val message = ProducerRecords(batch)
+
+    probe.send(producer, message)
+
+    probe.expectNoMsg(3.seconds)
 
     val results = consumeFromTopic(topic, 3, 10000)
 


### PR DESCRIPTION
Add a perf test for e2e scenario from KafkaConsumerActor to KafkaProducerActor with commit from sink confirmation to source commit.

Some minor tweaks in prep for 0.7.