### PR TITLE
Update Kafka Client to 0.10.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Scala support for Apache Kafka's Java client library 0.9.0.x to 0.10.0.0
+# Scala support for Apache Kafka's Java client library 0.9.0.x and 0.10.0.0
 
-This project comprises a few helper modules for operating the [Kafka Java Client Driver](https://kafka.apache.org/090/javadoc/index.html) in a Scala codebase.
+This project comprises a few helper modules for operating the [Kafka Java Client Driver](https://kafka.apache.org/0100/javadoc/index.html) in a Scala codebase.
 
 * [Scala Kafka Client](#scala-kafka-client)
 * [Scala Kafka Client - Akka Integration](#scala-kafka-client---akka-integration)
@@ -29,15 +29,21 @@ For configuration and usage, see the Wiki: [Scala Kafka Client Guide](https://gi
 
  scala-kafka-client | Kafka Java Driver
  ------------------ | -----------------
- 0.8.x | 0.10.0.0
- 0.7.x | 0.9.0.1
- 0.6.x | 0.9.0.1
- 0.5.x | 0.9.0.1
- 0.4  | 0.9.0.0
+ 0.8.0 | 0.10.0.0
+ 0.7.0 | 0.9.0.1
+
+### Change log
+
+#### 0.8.0 - 06/2016
+* Supports Kafka Client 0.10.0.0
+* Add max.poll.records config option to consumer
+
+#### 0.7.0 - 05/2016
+* Supports Kafka Client 0.9.0.1
 
 ### Resolve
 
-    libraryDependencies += "net.cakesolutions" %% "scala-kafka-client" % "0.7.0"
+    libraryDependencies += "net.cakesolutions" %% "scala-kafka-client" % "0.8.0"
 
 ## Scala Kafka Client - Akka Integration
 
@@ -50,7 +56,7 @@ concern for message delivery guarantees and resilience.
 
 ### Resolve
 
-    libraryDependencies += "net.cakesolutions" %% "scala-kafka-client-akka" % "0.7.0"
+    libraryDependencies += "net.cakesolutions" %% "scala-kafka-client-akka" % "0.8.0"
 
 ## TestKit
  
@@ -63,7 +69,7 @@ depends on a running Kafka Server.  Helps the setup of an in-process Kafka and Z
 ### Resolve
 
     //For kafka integration test support:
-    libraryDependencies += "net.cakesolutions" %% "scala-kafka-client-testkit" % "0.7.0" % "test"
+    libraryDependencies += "net.cakesolutions" %% "scala-kafka-client-testkit" % "0.8.0" % "test"
 
 ## License
     

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Scala support for Apache Kafka's Java client library 0.9.0.x
+# Scala support for Apache Kafka's Java client library 0.9.0.x to 0.10.0.0
 
 This project comprises a few helper modules for operating the [Kafka Java Client Driver](https://kafka.apache.org/090/javadoc/index.html) in a Scala codebase.
 
@@ -29,6 +29,7 @@ For configuration and usage, see the Wiki: [Scala Kafka Client Guide](https://gi
 
  scala-kafka-client | Kafka Java Driver
  ------------------ | -----------------
+ 0.8.x | 0.10.0.0
  0.7.x | 0.9.0.1
  0.6.x | 0.9.0.1
  0.5.x | 0.9.0.1

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ processing in an Akka application.  These components are specifically intended f
 concern for message delivery guarantees and resilience.
 
 ### Documentation
-[Kafka Client - Akka Integration](https://github.com/cakesolutions/scala-kafka-client/wiki/Akka-Kafka-Client)
+[Kafka Client - Akka Integration](https://github.com/cakesolutions/scala-kafka-client/wiki/Akka-Integration)
 
 ### Resolve
 

--- a/build.sbt
+++ b/build.sbt
@@ -40,6 +40,7 @@ lazy val commonSettings = Seq(
         <url>https://github.com/jkpl</url>
       </developer>
     </developers>,
+  resolvers += "Apache Staging repo" at "https://repository.apache.org/content/groups/staging",
 
   licenses := ("MIT", url("http://opensource.org/licenses/MIT")) :: Nil
 )

--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,6 @@ lazy val commonSettings = Seq(
         <url>https://github.com/jkpl</url>
       </developer>
     </developers>,
-  resolvers += "Apache Staging repo" at "https://repository.apache.org/content/groups/staging",
 
   licenses := ("MIT", url("http://opensource.org/licenses/MIT")) :: Nil
 )

--- a/client/src/main/scala/cakesolutions/kafka/KafkaConsumer.scala
+++ b/client/src/main/scala/cakesolutions/kafka/KafkaConsumer.scala
@@ -31,6 +31,7 @@ object KafkaConsumer {
       * @param autoCommitInterval the frequency in milliseconds that the consumer offsets are auto-committed to Kafka when auto commit is enabled
       * @param sessionTimeoutMs the timeout used to detect failures when using Kafka's group management facilities
       * @param maxPartitionFetchBytes the maximum amount of data per-partition the server will return
+      * @param maxPollRecords the maximum number of records returned in a single call to poll()
       * @param autoOffsetReset what to do when there is no initial offset in Kafka or if the current offset does not exist any more on the server
       * @tparam K key deserialiser type
       * @tparam V value deserialiser type
@@ -44,6 +45,7 @@ object KafkaConsumer {
                     autoCommitInterval: Int = 1000,
                     sessionTimeoutMs: Int = 30000,
                     maxPartitionFetchBytes: String = 262144.toString,
+                    maxPollRecords: Int = Integer.MAX_VALUE,
                     autoOffsetReset: OffsetResetStrategy = OffsetResetStrategy.LATEST): Conf[K, V] = {
 
       val configMap = Map[String, AnyRef](
@@ -53,6 +55,7 @@ object KafkaConsumer {
         ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG -> autoCommitInterval.toString,
         ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG -> sessionTimeoutMs.toString,
         ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG -> maxPartitionFetchBytes,
+        ConsumerConfig.MAX_POLL_RECORDS_CONFIG -> maxPollRecords.toString,
         ConsumerConfig.AUTO_OFFSET_RESET_CONFIG -> autoOffsetReset.toString.toLowerCase
       )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,6 +3,6 @@ object Dependencies {
     val slf4j = "1.7.12"
     val scalaTest = "3.0.0-M15"
     val akka = "2.4.1"
-    val kafka = "0.9.0.1"
+    val kafka = "0.10.0.0"
   }
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,6 +4,6 @@ addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.8.0")
 
 addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.0")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.3")
 
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.3")


### PR DESCRIPTION
- [x] Initial version against 0.10.0.0 Release Candidate
- [x] All tests passing

- [x] Wait for official release
- [x] Add max.poll.records config option to consumer
- [x] Should we support interceptors?  https://issues.apache.org/jira/browse/KAFKA-3162 - potentially could add to producer and consumer conf, if there is demand.
- [x] Check if any of the new Consumer api variants are useful: https://issues.apache.org/jira/browse/KAFKA-3006
