### PR TITLE
Refactor type cast

### DIFF
--- a/akka/src/main/scala/cakesolutions/kafka/akka/ConsumerRecords.scala
+++ b/akka/src/main/scala/cakesolutions/kafka/akka/ConsumerRecords.scala
@@ -96,10 +96,7 @@ object ConsumerRecords {
     * @return an extractor for given key and value types
     */
   def extractor[Key: TypeTag, Value: TypeTag]: Extractor[Any, ConsumerRecords[Key, Value]] =
-    Extractor {
-      case rs: ConsumerRecords[_, _] => rs.cast[Key, Value]
-      case _ => None
-    }
+    new TypeTaggedExtractor[ConsumerRecords[Key, Value]]
 }
 
 /**
@@ -110,39 +107,10 @@ object ConsumerRecords {
   * @tparam Key type of the key in records
   * @tparam Value type of the value in records
   */
-case class ConsumerRecords[Key: TypeTag, Value: TypeTag](offsets: Offsets, records: JConsumerRecords[Key, Value])
-  extends HasOffsets {
+final case class ConsumerRecords[Key: TypeTag, Value: TypeTag](offsets: Offsets, records: JConsumerRecords[Key, Value])
+  extends TypeTagged[ConsumerRecords[Key, Value]] with HasOffsets {
 
   import ConsumerRecords.Pair
-
-  val keyTag: TypeTag[Key] = typeTag[Key]
-  val valueTag: TypeTag[Value] = typeTag[Value]
-
-  /**
-    * Compare given types to key-value types.
-    *
-    * Useful for regaining generic type information in runtime when it has been lost (e.g. in actor communication).
-    *
-    * @tparam OtherKey the key type to compare to
-    * @tparam OtherValue the value type to compare to
-    * @return true when given types match object's type parameters, and false otherwise
-    */
-  def hasType[OtherKey: TypeTag, OtherValue: TypeTag]: Boolean =
-    typeTag[OtherKey].tpe <:< keyTag.tpe &&
-      typeTag[OtherValue].tpe <:< valueTag.tpe
-
-  /**
-    * Attempt to cast key-value pairs to given types.
-    *
-    * Useful for regaining generic type information in runtime when it has been lost (e.g. in actor communication).
-    *
-    * @tparam OtherKey the key type to cast to
-    * @tparam OtherValue the value type to cast to
-    * @return the same records in casted form when casting is possible, and otherwise `None`
-    */
-  def cast[OtherKey: TypeTag, OtherValue: TypeTag]: Option[ConsumerRecords[OtherKey, OtherValue]] =
-    if (hasType[OtherKey, OtherValue]) Some(this.asInstanceOf[ConsumerRecords[OtherKey, OtherValue]])
-    else None
 
   /**
     * Convert to Kafka's `ProducerRecord`s.

--- a/akka/src/main/scala/cakesolutions/kafka/akka/Extractor.scala
+++ b/akka/src/main/scala/cakesolutions/kafka/akka/Extractor.scala
@@ -15,7 +15,7 @@ trait Extractor[I, O] {
   * Helper functions for [[Extractor]].
   */
 object Extractor {
-  private class Ext[I, O](f: I => Option[O]) extends Extractor[I, O] {
+  private final class Ext[I, O](f: I => Option[O]) extends Extractor[I, O] {
     override def unapply(input: I): Option[O] = f(input)
   }
 

--- a/akka/src/main/scala/cakesolutions/kafka/akka/KafkaConsumerActor.scala
+++ b/akka/src/main/scala/cakesolutions/kafka/akka/KafkaConsumerActor.scala
@@ -37,7 +37,7 @@ object KafkaConsumerActor {
     *
     * @param offsets Consumption starts from specified offsets or kafka default, depending on `auto.offset.reset` setting.
     */
-  case class Subscribe(offsets: Option[Offsets] = None)
+  final case class Subscribe(offsets: Option[Offsets] = None)
 
   /**
     * Actor API - Confirm receipt of previous records.
@@ -49,7 +49,7 @@ object KafkaConsumerActor {
     * @param offsets the offsets that are to be confirmed
     * @param commit  true to commit offsets
     */
-  case class Confirm(offsets: Offsets, commit: Boolean = false)
+  final case class Confirm(offsets: Offsets, commit: Boolean = false)
 
   /**
     * Actor API - Unsubscribe from Kafka.
@@ -91,7 +91,7 @@ object KafkaConsumerActor {
     *                           To disable message redelivery provide a duration of 0.
     * @param retryStrategy      Strategy to follow on Kafka driver failures. Default: infinitely on one second intervals
     */
-  case class Conf(topics: List[String],
+  final case class Conf(topics: List[String],
                   scheduleInterval: FiniteDuration = 1000.millis,
                   unconfirmedTimeout: FiniteDuration = 3.seconds,
                   retryStrategy: Retry.Strategy = Retry.Strategy(Retry.Interval.Linear(1.second), Retry.Logic.Infinite)) {
@@ -147,7 +147,7 @@ object KafkaConsumerActor {
   }
 }
 
-private class KafkaConsumerActor[K: TypeTag, V: TypeTag](
+private final class KafkaConsumerActor[K: TypeTag, V: TypeTag](
   consumerConf: KafkaConsumer.Conf[K, V],
   actorConf: KafkaConsumerActor.Conf,
   downstreamActor: ActorRef)
@@ -173,10 +173,10 @@ private class KafkaConsumerActor[K: TypeTag, V: TypeTag](
     def isCurrentOffset(offsets: Offsets): Boolean = unconfirmed.offsets == offsets
   }
 
-  private case class Unconfirmed(unconfirmed: Records, deliveryTime: LocalDateTime = LocalDateTime.now())
+  private final case class Unconfirmed(unconfirmed: Records, deliveryTime: LocalDateTime = LocalDateTime.now())
     extends HasUnconfirmedRecords
 
-  private case class Buffered(unconfirmed: Records, deliveryTime: LocalDateTime = LocalDateTime.now(), buffered: Records)
+  private final case class Buffered(unconfirmed: Records, deliveryTime: LocalDateTime = LocalDateTime.now(), buffered: Records)
     extends HasUnconfirmedRecords
 
   override def receive = unsubscribed

--- a/akka/src/main/scala/cakesolutions/kafka/akka/KafkaProducerActor.scala
+++ b/akka/src/main/scala/cakesolutions/kafka/akka/KafkaProducerActor.scala
@@ -32,7 +32,7 @@ object KafkaProducerActor {
     * @tparam K Kafka message key type
     * @tparam V Kafka message value type
     */
-  case class MatcherResult[K, V](records: Iterable[ProducerRecord[K, V]], response: Option[Any])
+  final case class MatcherResult[K, V](records: Iterable[ProducerRecord[K, V]], response: Option[Any])
 
   /**
     * A partial function that extracts producer records from messages sent to [[KafkaProducerActor]].
@@ -159,7 +159,7 @@ private class KafkaProducerActor[K, V](producerConf: KafkaProducer.Conf[K, V], m
   }
 }
 
-class KafkaProducerInitFail(
+final class KafkaProducerInitFail(
   message: String = "Error occurred while initializing Kafka producer!",
   cause: Throwable = null)
   extends Exception(message, cause)

--- a/akka/src/main/scala/cakesolutions/kafka/akka/Offsets.scala
+++ b/akka/src/main/scala/cakesolutions/kafka/akka/Offsets.scala
@@ -22,7 +22,7 @@ object Offsets {
   * Because the offsets are unique to the consumed batch,
   * the offsets are also used as a confirmation key for confirming that the batch has been fully processed.
   */
-case class Offsets(offsetsMap: Map[TopicPartition, Long]) extends AnyVal {
+final case class Offsets(offsetsMap: Map[TopicPartition, Long]) extends AnyVal {
 
   /**
     * Get offset for a topic & partition pair.

--- a/akka/src/main/scala/cakesolutions/kafka/akka/Retry.scala
+++ b/akka/src/main/scala/cakesolutions/kafka/akka/Retry.scala
@@ -22,7 +22,7 @@ object Retry {
         case t => sys.error(s"Unexpected interval type: $t")
       }
 
-    case class Linear(duration: FiniteDuration) extends Interval {
+    final case class Linear(duration: FiniteDuration) extends Interval {
       def next: Interval = this
     }
   }
@@ -45,7 +45,7 @@ object Retry {
       def isFinished: Boolean = false
     }
 
-    case class FiniteTimes(retryCount: Int) extends Logic {
+    final case class FiniteTimes(retryCount: Int) extends Logic {
       require(retryCount >= 0, "Retry count cannot be negative")
 
       def next: Logic = FiniteTimes(retryCount - 1)
@@ -61,7 +61,7 @@ object Retry {
       )
   }
 
-  case class Strategy(interval: Interval, retryLogic: Logic) {
+  final case class Strategy(interval: Interval, retryLogic: Logic) {
     def next: Strategy = Strategy(interval.next, retryLogic.next)
     def isFinished: Boolean = retryLogic.isFinished
     def evaluate[T](f: => T): Result[T] =
@@ -78,9 +78,9 @@ object Retry {
   sealed trait Result[+T]
 
   object Result {
-    case class Next(error: Throwable, strategy: Strategy) extends Result[Nothing]
-    case class Failure(error: Throwable) extends Result[Nothing]
-    case class Success[+T](value: T) extends Result[T]
+    final case class Next(error: Throwable, strategy: Strategy) extends Result[Nothing]
+    final case class Failure(error: Throwable) extends Result[Nothing]
+    final case class Success[+T](value: T) extends Result[T]
   }
 }
 

--- a/akka/src/main/scala/cakesolutions/kafka/akka/TrackPartitions.scala
+++ b/akka/src/main/scala/cakesolutions/kafka/akka/TrackPartitions.scala
@@ -17,7 +17,7 @@ private object TrackPartitions {
 /**
  * Not thread safe. Can be used with Kafka consumer 0.9 API.
  */
-private class TrackPartitions(consumer: KafkaConsumer[_, _]) extends ConsumerRebalanceListener {
+private final class TrackPartitions(consumer: KafkaConsumer[_, _]) extends ConsumerRebalanceListener {
   import TrackPartitions.log
 
   private var _offsets = Map[TopicPartition, Long]()

--- a/akka/src/main/scala/cakesolutions/kafka/akka/TypeTagged.scala
+++ b/akka/src/main/scala/cakesolutions/kafka/akka/TypeTagged.scala
@@ -1,0 +1,52 @@
+package cakesolutions.kafka.akka
+
+import scala.reflect.runtime.universe.{TypeTag, typeOf, typeTag}
+
+trait TypeTaggedTrait[Self] { self: Self =>
+
+  /**
+    * The representation of this class's type at a value level.
+    *
+    * Useful for regaining generic type information in runtime when it has been lost (e.g. in actor communication).
+    */
+  val selfTypeTag: TypeTag[Self]
+
+  /**
+    * Compare the given type to the type of this class
+    *
+    * Useful for regaining generic type information in runtime when it has been lost (e.g. in actor communication).
+    *
+    * @return true if the types match and false otherwise
+    */
+  def hasType[Other: TypeTag]: Boolean =
+    typeOf[Other] =:= selfTypeTag.tpe
+
+  /**
+    * Attempt to cast this value to the given type.
+    *
+    * If the types match, the casted version is returned. Otherwise, empty value is returned.
+    *
+    * Useful for regaining generic type information in runtime when it has been lost (e.g. in actor communication).
+    *
+    * @return casted version wrapped in `Some` if the cast succeeds, and otherwise `None`
+    */
+  def cast[Other: TypeTag]: Option[Other] =
+    if (hasType[Other])
+      Some(this.asInstanceOf[Other])
+    else
+      None
+}
+
+abstract class TypeTagged[Self: TypeTag] extends TypeTaggedTrait[Self] { self: Self =>
+  val selfTypeTag: TypeTag[Self] = typeTag[Self]
+}
+
+/**
+  * Extractor for [[TypeTaggedTrait]] instances.
+  */
+final class TypeTaggedExtractor[T: TypeTag] extends Extractor[Any, T] {
+  override def unapply(a: Any): Option[T] = a match {
+    case t: TypeTaggedTrait[_] => t.cast[T]
+    case _ => None
+  }
+}

--- a/akka/src/test/scala/cakesolutions/kafka/akka/ConsumerRecordsSpec.scala
+++ b/akka/src/test/scala/cakesolutions/kafka/akka/ConsumerRecordsSpec.scala
@@ -10,13 +10,13 @@ class ConsumerRecordsSpec extends FlatSpecLike with Matchers with Inside {
   val anyInput: Any = knownInput
 
   "ConsumerRecords" should "match types correctly" in {
-    partiallyKnownInput.hasType[String, Int] shouldEqual true
-    partiallyKnownInput.hasType[Int, String] shouldEqual false
+    partiallyKnownInput.hasType[ConsumerRecords[String, Int]] shouldEqual true
+    partiallyKnownInput.hasType[ConsumerRecords[Int, String]] shouldEqual false
   }
 
   it should "cast to only correct types" in {
-    val success = partiallyKnownInput.cast[String, Int]
-    val failure = partiallyKnownInput.cast[Int, String]
+    val success = partiallyKnownInput.cast[ConsumerRecords[String, Int]]
+    val failure = partiallyKnownInput.cast[ConsumerRecords[Int, String]]
 
     success shouldEqual Some(knownInput)
     failure shouldEqual None

--- a/client/src/main/scala/cakesolutions/kafka/KafkaConsumer.scala
+++ b/client/src/main/scala/cakesolutions/kafka/KafkaConsumer.scala
@@ -89,7 +89,7 @@ object KafkaConsumer {
     * @tparam K key deserializer type
     * @tparam V value deserializer type
     */
-  case class Conf[K, V](props: Map[String, AnyRef],
+  final case class Conf[K, V](props: Map[String, AnyRef],
                         keyDeserializer: Deserializer[K],
                         valueDeserializer: Deserializer[V]) {
 

--- a/client/src/main/scala/cakesolutions/kafka/KafkaProducer.scala
+++ b/client/src/main/scala/cakesolutions/kafka/KafkaProducer.scala
@@ -86,7 +86,7 @@ object KafkaProducer {
     * @tparam K key serializer type
     * @tparam V value serializer type
     */
-  case class Conf[K, V](props: Map[String, AnyRef],
+  final case class Conf[K, V](props: Map[String, AnyRef],
                         keySerializer: Serializer[K],
                         valueSerializer: Serializer[V]) {
 
@@ -139,7 +139,7 @@ object KafkaProducer {
   * @tparam K type of the key that the producer accepts
   * @tparam V type of the value that the producer accepts
   */
-class KafkaProducer[K, V](val producer: JKafkaProducer[K, V]) {
+final class KafkaProducer[K, V](val producer: JKafkaProducer[K, V]) {
 
   /**
     * Asynchronously send a record to a topic, providing a `Future` to contain the result of the operation.


### PR DESCRIPTION
Also, marked most of the classes `final`. Breaks API compatibility.