### PR TITLE
KafkaConsumerActor wrapper

### DIFF
--- a/akka/src/it/scala/cakesolutions/kafka/akka/KafkaE2EActorPerfSpec.scala
+++ b/akka/src/it/scala/cakesolutions/kafka/akka/KafkaE2EActorPerfSpec.scala
@@ -3,7 +3,7 @@ package cakesolutions.kafka.akka
 import akka.actor.{ActorRef, ActorSystem}
 import akka.testkit.TestActor.AutoPilot
 import akka.testkit.{ImplicitSender, TestActor, TestKit, TestProbe}
-import cakesolutions.kafka.akka.KafkaConsumerActor.{Confirm, Subscribe, Unsubscribe}
+import cakesolutions.kafka.akka.KafkaConsumerActor.Confirm
 import cakesolutions.kafka.testkit.TestUtils
 import cakesolutions.kafka.{KafkaConsumer, KafkaProducer, KafkaProducerRecord}
 import com.typesafe.config.ConfigFactory
@@ -68,7 +68,7 @@ class KafkaE2EActorPerfSpec(system_ : ActorSystem)
     val receiver = TestProbe()
     receiver.setAutoPilot(pilot)
 
-    val consumer = system.actorOf(KafkaConsumerActor.props(consumerConf, consumerActorConf(sourceTopic), receiver.ref))
+    val consumer = KafkaConsumerActor(consumerConf, consumerActorConf(sourceTopic), receiver.ref)
 
     1 to totalMessages foreach { n =>
       testProducer.send(KafkaProducerRecord(sourceTopic, None, msg1k))
@@ -76,7 +76,7 @@ class KafkaE2EActorPerfSpec(system_ : ActorSystem)
     testProducer.flush()
     log.info("Delivered {} messages to topic {}", totalMessages, sourceTopic)
 
-    consumer ! Subscribe()
+    consumer.subscribe()
 
     whenReady(pilot.future) { case (totalTime, messagesPerSec) =>
       log.info("Total Time millis : {}", totalTime)
@@ -84,7 +84,7 @@ class KafkaE2EActorPerfSpec(system_ : ActorSystem)
 
       totalTime should be < 7000L
 
-      consumer ! Unsubscribe
+      consumer.unsubscribe()
       testProducer.close()
       log.info("Done")
     }
@@ -113,9 +113,10 @@ class PipelinePilot(producer: ActorRef, targetTopic: String, expectedMessages: L
       case Some(r) =>
         total += r.size
 
-        producer.!(
-          ProducerRecords(r.toProducerRecords(targetTopic), Some(Confirm(r.offsets, commit = true)))
-        )(sender)
+        producer.tell(
+          msg = ProducerRecords(r.toProducerRecords(targetTopic), Some(Confirm(r.offsets, commit = true))),
+          sender = sender
+        )
 
         if (total >= expectedMessages) {
           val totalTime = System.currentTimeMillis() - start

--- a/akka/src/main/scala/cakesolutions/kafka/akka/KafkaConsumerActor.scala
+++ b/akka/src/main/scala/cakesolutions/kafka/akka/KafkaConsumerActor.scala
@@ -157,16 +157,16 @@ object KafkaConsumerActor {
     * @param downstreamActor the actor where all the consumed messages will be sent to
     * @tparam K key deserialiser type
     * @tparam V value deserialiser type
-    * @param as actor system to create the actor on
+    * @param actorFactory the actor factory to create the actor with
     */
   def apply[K: TypeTag, V: TypeTag](
     conf: Config,
     keyDeserializer: Deserializer[K],
     valueDeserializer: Deserializer[V],
     downstreamActor: ActorRef
-  )(implicit as: ActorSystem): KafkaConsumerActor = {
+  )(implicit actorFactory: ActorRefFactory): KafkaConsumerActor = {
     val p = props(conf, keyDeserializer, valueDeserializer, downstreamActor)
-    val ref = as.actorOf(p)
+    val ref = actorFactory.actorOf(p)
     fromActorRef(ref)
   }
 
@@ -178,15 +178,15 @@ object KafkaConsumerActor {
     * @param downstreamActor the actor where all the consumed messages will be sent to
     * @tparam K key deserialiser type
     * @tparam V value deserialiser type
-    * @param as actor system to create the actor on
+    * @param actorFactory the actor factory to create the actor with
     */
   def apply[K: TypeTag, V: TypeTag](
     consumerConf: KafkaConsumer.Conf[K, V],
     actorConf: KafkaConsumerActor.Conf,
     downstreamActor: ActorRef
-  )(implicit as: ActorSystem): KafkaConsumerActor = {
+  )(implicit actorFactory: ActorRefFactory): KafkaConsumerActor = {
     val p = props(consumerConf, actorConf, downstreamActor)
-    val ref = as.actorOf(p)
+    val ref = actorFactory.actorOf(p)
     fromActorRef(ref)
   }
 

--- a/akka/src/test/scala/cakesolutions/kafka/akka/KafkaConsumerActorSpec.scala
+++ b/akka/src/test/scala/cakesolutions/kafka/akka/KafkaConsumerActorSpec.scala
@@ -110,14 +110,14 @@ class KafkaConsumerActorSpec(system_ : ActorSystem) extends KafkaIntSpec(system_
           producer.send(KafkaProducerRecord(actorConf.topics.head, None, "value"))
           producer.flush()
 
-          val consumer = system.actorOf(KafkaConsumerActor.props(consumerConfig, actorConf, testActor))
-          consumer ! Subscribe()
+          val consumer = KafkaConsumerActor(consumerConfig, actorConf, testActor)
+          consumer.subscribe()
 
           val rs = expectMsgClass(30.seconds, classOf[ConsumerRecords[String, String]])
-          consumer ! Confirm(rs.offsets)
+          consumer.confirm(rs.offsets)
           expectNoMsg(5.seconds)
 
-          consumer ! Unsubscribe
+          consumer.unsubscribe()
           producer.close()
       }
   }

--- a/akka/src/test/scala/cakesolutions/kafka/akka/KafkaIntSpec.scala
+++ b/akka/src/test/scala/cakesolutions/kafka/akka/KafkaIntSpec.scala
@@ -1,7 +1,7 @@
 package cakesolutions.kafka.akka
 
 import akka.actor.ActorSystem
-import akka.testkit.{ImplicitSender, TestKit}
+import akka.testkit.TestKit
 import cakesolutions.kafka.testkit.KafkaServer
 import org.scalatest.concurrent.AsyncAssertions
 import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
@@ -9,8 +9,7 @@ import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
 /**
   * ScalaTest base class for scala-kafka-client-testkit based integration tests
   */
-class KafkaIntSpec(system: ActorSystem) extends TestKit(system)
-  with ImplicitSender
+class KafkaIntSpec(_system: ActorSystem) extends TestKit(_system)
   with AsyncAssertions
   with FlatSpecLike
   with Matchers


### PR DESCRIPTION
Wrapper type around Kafka consumer actor. Provides an API that isn't based on actor messages.