### PR TITLE
0.10.1.0 support

### DIFF
--- a/akka/src/it/scala/cakesolutions/kafka/akka/KafkaConsumerActorPerfSpec.scala
+++ b/akka/src/it/scala/cakesolutions/kafka/akka/KafkaConsumerActorPerfSpec.scala
@@ -7,6 +7,7 @@ import cakesolutions.kafka.akka.KafkaConsumerActor.Confirm
 import cakesolutions.kafka.akka.KafkaConsumerActor.Subscribe.AutoPartition
 import cakesolutions.kafka.{KafkaConsumer, KafkaProducer, KafkaProducerRecord}
 import com.typesafe.config.ConfigFactory
+import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.common.serialization.{StringDeserializer, StringSerializer}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Millis, Seconds, Span}
@@ -46,7 +47,7 @@ class KafkaConsumerActorPerfSpec(system_ : ActorSystem)
     KafkaConsumer.Conf(config.getConfig("consumer"),
       new StringDeserializer,
       new StringDeserializer
-    )
+    ).withProperty(ConsumerConfig.METADATA_MAX_AGE_CONFIG, "30000")
   }
 
   def actorConf: KafkaConsumerActor.Conf =

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,4 @@
 lazy val commonSettings = Seq(
-  resolvers += "Apache Staging" at "https://repository.apache.org/content/groups/staging/",
   organization := "net.cakesolutions",
   scalaVersion := "2.11.8",
   publishMavenStyle := true,

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
 lazy val commonSettings = Seq(
+  resolvers += "Apache Staging" at "https://repository.apache.org/content/groups/staging/",
   organization := "net.cakesolutions",
   scalaVersion := "2.11.8",
   publishMavenStyle := true,

--- a/client/src/main/scala/cakesolutions/kafka/KafkaConsumer.scala
+++ b/client/src/main/scala/cakesolutions/kafka/KafkaConsumer.scala
@@ -18,13 +18,14 @@ object KafkaConsumer {
 
   /**
     * Implicit conversion to support calling the org.apache.kafka.clients.consumer.KafkaConsumer.offsetsForTimes method with a Map[TopicPartition, scala.Long].
+    *
     * @param offsetQuery
     * @return
     */
   implicit def toJavaOffsetQuery(offsetQuery: Map[TopicPartition, scala.Long]): java.util.Map[TopicPartition, java.lang.Long] =
-  offsetQuery.map { case (tp, time) =>
-    tp -> new java.lang.Long(time)
-  }
+    offsetQuery.map { case (tp, time) =>
+      tp -> new java.lang.Long(time)
+    }
 
   /**
     * Utilities for creating Kafka consumer configurations.
@@ -35,17 +36,17 @@ object KafkaConsumer {
       * Kafka consumer configuration constructor with common configurations as parameters.
       * For more detailed configuration, use the other [[Conf]] constructors.
       *
-      * @param keyDeserializer        deserializer for the key
-      * @param valueDeserializer      deserializer for the value
-      * @param bootstrapServers       a list of host/port pairs to use for establishing the initial connection to the Kafka cluster
-      * @param groupId                a unique string that identifies the consumer group this consumer belongs to
-      * @param enableAutoCommit       if true the consumer's offsets will be periodically committed in the background
-      * @param autoCommitInterval     the frequency in milliseconds that the consumer offsets are auto-committed to Kafka when auto commit is enabled
-      * @param sessionTimeoutMs       the timeout used to detect failures when using Kafka's group management facilities
+      * @param keyDeserializer deserializer for the key
+      * @param valueDeserializer deserializer for the value
+      * @param bootstrapServers a list of host/port pairs to use for establishing the initial connection to the Kafka cluster
+      * @param groupId a unique string that identifies the consumer group this consumer belongs to
+      * @param enableAutoCommit if true the consumer's offsets will be periodically committed in the background
+      * @param autoCommitInterval the frequency in milliseconds that the consumer offsets are auto-committed to Kafka when auto commit is enabled
+      * @param sessionTimeoutMs the timeout used to detect failures when using Kafka's group management facilities
       * @param maxPartitionFetchBytes the maximum amount of data per-partition the server will return
-      * @param maxPollRecords         the maximum number of records returned in a single call to poll()
-      * @param maxPollInterval        the maximum delay between invocations of poll() when using consumer group management
-      * @param autoOffsetReset        what to do when there is no initial offset in Kafka or if the current offset does not exist any more on the server
+      * @param maxPollRecords the maximum number of records returned in a single call to poll()
+      * @param maxPollInterval the maximum delay between invocations of poll() when using consumer group management
+      * @param autoOffsetReset what to do when there is no initial offset in Kafka or if the current offset does not exist any more on the server
       * @tparam K key deserialiser type
       * @tparam V value deserialiser type
       * @return consumer configuration consisting of all the given values
@@ -82,15 +83,15 @@ object KafkaConsumer {
       *
       * The configuration names and values must match the Kafka's `ConsumerConfig` style.
       *
-      * @param config            a Typesafe config to build configuration from
-      * @param keyDeserializer   deserialiser for the key
+      * @param config a Typesafe config to build configuration from
+      * @param keyDeserializer deserialiser for the key
       * @param valueDeserializer deserialiser for the value
       * @tparam K key deserialiser type
       * @tparam V value deserialiser type
       * @return consumer configuration
       */
     def apply[K, V](config: Config, keyDeserializer: Deserializer[K], valueDeserializer: Deserializer[V]): Conf[K, V] =
-    apply(config.toPropertyMap, keyDeserializer, valueDeserializer)
+      apply(config.toPropertyMap, keyDeserializer, valueDeserializer)
   }
 
   /**
@@ -115,19 +116,19 @@ object KafkaConsumer {
       * The supplied config overrides existing properties.
       */
     def withConf(config: Config): Conf[K, V] =
-    copy(props = props ++ config.toPropertyMap)
+      copy(props = props ++ config.toPropertyMap)
 
     /**
       * Is auto commit mode in use.
       */
     def isAutoCommitMode: Boolean =
-    props.getOrElse(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "").toString.equals("true")
+      props.getOrElse(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "").toString.equals("true")
 
     /**
       * Extend the configuration with a single key-value pair.
       */
     def withProperty(key: String, value: AnyRef) =
-    copy(props = props + (key -> value))
+      copy(props = props + (key -> value))
   }
 
   /**
@@ -139,5 +140,5 @@ object KafkaConsumer {
     * @return Kafka consumer client
     */
   def apply[K, V](conf: Conf[K, V]): JKafkaConsumer[K, V] =
-  new JKafkaConsumer[K, V](conf.props, conf.keyDeserializer, conf.valueDeserializer)
+    new JKafkaConsumer[K, V](conf.props, conf.keyDeserializer, conf.valueDeserializer)
 }

--- a/client/src/main/scala/cakesolutions/kafka/KafkaConsumer.scala
+++ b/client/src/main/scala/cakesolutions/kafka/KafkaConsumer.scala
@@ -33,21 +33,23 @@ object KafkaConsumer {
       * @param sessionTimeoutMs the timeout used to detect failures when using Kafka's group management facilities
       * @param maxPartitionFetchBytes the maximum amount of data per-partition the server will return
       * @param maxPollRecords the maximum number of records returned in a single call to poll()
+      * @param maxPollInterval the maximum delay between invocations of poll() when using consumer group management
       * @param autoOffsetReset what to do when there is no initial offset in Kafka or if the current offset does not exist any more on the server
       * @tparam K key deserialiser type
       * @tparam V value deserialiser type
       * @return consumer configuration consisting of all the given values
       */
     def apply[K, V](keyDeserializer: Deserializer[K],
-                    valueDeserializer: Deserializer[V],
-                    bootstrapServers: String = "localhost:9092",
-                    groupId: String,
-                    enableAutoCommit: Boolean = true,
-                    autoCommitInterval: Int = 1000,
-                    sessionTimeoutMs: Int = 30000,
-                    maxPartitionFetchBytes: Int = ConsumerConfig.DEFAULT_MAX_PARTITION_FETCH_BYTES,
-                    maxPollRecords: Int = Integer.MAX_VALUE,
-                    autoOffsetReset: OffsetResetStrategy = OffsetResetStrategy.LATEST): Conf[K, V] = {
+      valueDeserializer: Deserializer[V],
+      bootstrapServers: String = "localhost:9092",
+      groupId: String,
+      enableAutoCommit: Boolean = true,
+      autoCommitInterval: Int = 1000,
+      sessionTimeoutMs: Int = 10000,
+      maxPartitionFetchBytes: Int = ConsumerConfig.DEFAULT_MAX_PARTITION_FETCH_BYTES,
+      maxPollRecords: Int = 500,
+      maxPollInterval: Int = 300000,
+      autoOffsetReset: OffsetResetStrategy = OffsetResetStrategy.LATEST): Conf[K, V] = {
 
       val configMap = Map[String, AnyRef](
         ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG -> bootstrapServers,
@@ -57,6 +59,7 @@ object KafkaConsumer {
         ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG -> sessionTimeoutMs.toString,
         ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG -> maxPartitionFetchBytes.toString,
         ConsumerConfig.MAX_POLL_RECORDS_CONFIG -> maxPollRecords.toString,
+        ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG -> maxPollInterval.toString,
         ConsumerConfig.AUTO_OFFSET_RESET_CONFIG -> autoOffsetReset.toString.toLowerCase
       )
 

--- a/client/src/main/scala/cakesolutions/kafka/KafkaConsumer.scala
+++ b/client/src/main/scala/cakesolutions/kafka/KafkaConsumer.scala
@@ -3,9 +3,10 @@ package cakesolutions.kafka
 import cakesolutions.kafka.TypesafeConfigExtensions._
 import com.typesafe.config.Config
 import org.apache.kafka.clients.consumer.{ConsumerConfig, OffsetResetStrategy, KafkaConsumer => JKafkaConsumer}
+import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.serialization.Deserializer
-
 import scala.collection.JavaConversions._
+import scala.language.implicitConversions
 
 /**
   * Utilities for creating a Kafka consumer.
@@ -16,6 +17,16 @@ import scala.collection.JavaConversions._
 object KafkaConsumer {
 
   /**
+    * Implicit conversion to support calling the org.apache.kafka.clients.consumer.KafkaConsumer.offsetsForTimes method with a Map[TopicPartition, scala.Long].
+    * @param offsetQuery
+    * @return
+    */
+  implicit def toJavaOffsetQuery(offsetQuery: Map[TopicPartition, scala.Long]): java.util.Map[TopicPartition, java.lang.Long] =
+  offsetQuery.map { case (tp, time) =>
+    tp -> new java.lang.Long(time)
+  }
+
+  /**
     * Utilities for creating Kafka consumer configurations.
     */
   object Conf {
@@ -24,17 +35,17 @@ object KafkaConsumer {
       * Kafka consumer configuration constructor with common configurations as parameters.
       * For more detailed configuration, use the other [[Conf]] constructors.
       *
-      * @param keyDeserializer deserializer for the key
-      * @param valueDeserializer deserializer for the value
-      * @param bootstrapServers a list of host/port pairs to use for establishing the initial connection to the Kafka cluster
-      * @param groupId a unique string that identifies the consumer group this consumer belongs to
-      * @param enableAutoCommit if true the consumer's offsets will be periodically committed in the background
-      * @param autoCommitInterval the frequency in milliseconds that the consumer offsets are auto-committed to Kafka when auto commit is enabled
-      * @param sessionTimeoutMs the timeout used to detect failures when using Kafka's group management facilities
+      * @param keyDeserializer        deserializer for the key
+      * @param valueDeserializer      deserializer for the value
+      * @param bootstrapServers       a list of host/port pairs to use for establishing the initial connection to the Kafka cluster
+      * @param groupId                a unique string that identifies the consumer group this consumer belongs to
+      * @param enableAutoCommit       if true the consumer's offsets will be periodically committed in the background
+      * @param autoCommitInterval     the frequency in milliseconds that the consumer offsets are auto-committed to Kafka when auto commit is enabled
+      * @param sessionTimeoutMs       the timeout used to detect failures when using Kafka's group management facilities
       * @param maxPartitionFetchBytes the maximum amount of data per-partition the server will return
-      * @param maxPollRecords the maximum number of records returned in a single call to poll()
-      * @param maxPollInterval the maximum delay between invocations of poll() when using consumer group management
-      * @param autoOffsetReset what to do when there is no initial offset in Kafka or if the current offset does not exist any more on the server
+      * @param maxPollRecords         the maximum number of records returned in a single call to poll()
+      * @param maxPollInterval        the maximum delay between invocations of poll() when using consumer group management
+      * @param autoOffsetReset        what to do when there is no initial offset in Kafka or if the current offset does not exist any more on the server
       * @tparam K key deserialiser type
       * @tparam V value deserialiser type
       * @return consumer configuration consisting of all the given values
@@ -71,15 +82,15 @@ object KafkaConsumer {
       *
       * The configuration names and values must match the Kafka's `ConsumerConfig` style.
       *
-      * @param config a Typesafe config to build configuration from
-      * @param keyDeserializer deserialiser for the key
+      * @param config            a Typesafe config to build configuration from
+      * @param keyDeserializer   deserialiser for the key
       * @param valueDeserializer deserialiser for the value
       * @tparam K key deserialiser type
       * @tparam V value deserialiser type
       * @return consumer configuration
       */
     def apply[K, V](config: Config, keyDeserializer: Deserializer[K], valueDeserializer: Deserializer[V]): Conf[K, V] =
-      apply(config.toPropertyMap, keyDeserializer, valueDeserializer)
+    apply(config.toPropertyMap, keyDeserializer, valueDeserializer)
   }
 
   /**
@@ -104,19 +115,19 @@ object KafkaConsumer {
       * The supplied config overrides existing properties.
       */
     def withConf(config: Config): Conf[K, V] =
-      copy(props = props ++ config.toPropertyMap)
+    copy(props = props ++ config.toPropertyMap)
 
     /**
       * Is auto commit mode in use.
       */
     def isAutoCommitMode: Boolean =
-      props.getOrElse(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "").toString.equals("true")
+    props.getOrElse(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "").toString.equals("true")
 
     /**
       * Extend the configuration with a single key-value pair.
       */
     def withProperty(key: String, value: AnyRef) =
-      copy(props = props + (key -> value))
+    copy(props = props + (key -> value))
   }
 
   /**
@@ -128,5 +139,5 @@ object KafkaConsumer {
     * @return Kafka consumer client
     */
   def apply[K, V](conf: Conf[K, V]): JKafkaConsumer[K, V] =
-    new JKafkaConsumer[K, V](conf.props, conf.keyDeserializer, conf.valueDeserializer)
+  new JKafkaConsumer[K, V](conf.props, conf.keyDeserializer, conf.valueDeserializer)
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,8 +1,8 @@
 object Dependencies {
   object versions {
     val slf4j = "1.7.21"
-    val scalaTest = "3.0.0-RC4"
+    val scalaTest = "3.0.0"
     val akka = "2.4.8"
-    val kafka = "0.10.0.1"
+    val kafka = "0.10.1.0"
   }
 }


### PR DESCRIPTION
Initial support for Kafka 0.10.1.0.

This version of the Java driver introduces a dedicated, blocking background thread per consumer, which is disappointing.  We need to keep paying attention to what proposals the Kafka team are making regarding the driver, as they doesn't seem to be considering a reactive style of programming as a usage case.  Might also be worth trying to propose/ submit a change to the Java driver to make the background thread optional and callable via an api method, so we can call it from an Akka dispatcher.
- [x] Tests pass
- [x] Remove apache snapshot repo

Ready for review
