### PR TITLE
Make producer record key types consistent

### DIFF
--- a/akka/src/main/scala/cakesolutions/kafka/akka/ProducerRecords.scala
+++ b/akka/src/main/scala/cakesolutions/kafka/akka/ProducerRecords.scala
@@ -43,7 +43,7 @@ object ProducerRecords {
     */
   def fromValuesWithKey[Key: TypeTag, Value: TypeTag](
     topic: String,
-    key: Key,
+    key: Option[Key],
     values: Seq[Value],
     successResponse: Option[Any],
     failureResponse: Option[Any]
@@ -84,7 +84,7 @@ object ProducerRecords {
     */
   def fromKeyValues[Key: TypeTag, Value: TypeTag](
     topic: String,
-    keyValues: Seq[(Key, Value)],
+    keyValues: Seq[(Option[Key], Value)],
     successResponse: Option[Any],
     failureResponse: Option[Any]
   ): ProducerRecords[Key, Value] =
@@ -102,10 +102,10 @@ object ProducerRecords {
     * @param failureResponse optional response message to the sender on failed delivery
     */
   def fromKeyValuesWithTopic[Key: TypeTag, Value: TypeTag](
-    keyValuesWithTopic: Seq[(String, Key, Value)],
+    keyValuesWithTopic: Seq[(String, Option[Key], Value)],
     successResponse: Option[Any],
     failureResponse: Option[Any]
-  ): ProducerRecords[Key, Value] =
+  ): ProducerRecords[Option[Key], Value] =
     ProducerRecords(
       KafkaProducerRecord.fromKeyValuesWithTopic(keyValuesWithTopic),
       successResponse,

--- a/akka/src/main/scala/cakesolutions/kafka/akka/ProducerRecords.scala
+++ b/akka/src/main/scala/cakesolutions/kafka/akka/ProducerRecords.scala
@@ -105,7 +105,7 @@ object ProducerRecords {
     keyValuesWithTopic: Seq[(String, Option[Key], Value)],
     successResponse: Option[Any],
     failureResponse: Option[Any]
-  ): ProducerRecords[Option[Key], Value] =
+  ): ProducerRecords[Key, Value] =
     ProducerRecords(
       KafkaProducerRecord.fromKeyValuesWithTopic(keyValuesWithTopic),
       successResponse,

--- a/client/src/main/scala/cakesolutions/kafka/KafkaProducerRecord.scala
+++ b/client/src/main/scala/cakesolutions/kafka/KafkaProducerRecord.scala
@@ -127,7 +127,7 @@ object KafkaProducerRecord {
     * @param key key of the records
     * @param values values of the records
     */
-  def fromValuesWithKey[Key, Value](topic: String, key: Key, values: Seq[Value]): Seq[ProducerRecord[Key, Value]] =
+  def fromValuesWithKey[Key, Value](topic: String, key: Option[Key], values: Seq[Value]): Seq[ProducerRecord[Key, Value]] =
     values.map(value => KafkaProducerRecord(topic, key, value))
 
   /**
@@ -148,7 +148,7 @@ object KafkaProducerRecord {
     * @param topic topic to write the records to
     * @param keyValues a sequence of key and value pairs
     */
-  def fromKeyValues[Key, Value](topic: String, keyValues: Seq[(Key, Value)]): Seq[ProducerRecord[Key, Value]] =
+  def fromKeyValues[Key, Value](topic: String, keyValues: Seq[(Option[Key], Value)]): Seq[ProducerRecord[Key, Value]] =
     keyValues.map {
       case (key, value) => KafkaProducerRecord(topic, key, value)
     }

--- a/client/src/main/scala/cakesolutions/kafka/KafkaProducerRecord.scala
+++ b/client/src/main/scala/cakesolutions/kafka/KafkaProducerRecord.scala
@@ -158,7 +158,7 @@ object KafkaProducerRecord {
     *
     * @param keyValuesWithTopic a sequence of topic, key, and value triples.
     */
-  def fromKeyValuesWithTopic[Key, Value](keyValuesWithTopic: Iterable[(String, Key, Value)]): Iterable[ProducerRecord[Key, Value]] =
+  def fromKeyValuesWithTopic[Key, Value](keyValuesWithTopic: Iterable[(String, Option[Key], Value)]): Iterable[ProducerRecord[Key, Value]] =
     keyValuesWithTopic.map {
       case (topic, key, value) => KafkaProducerRecord(topic, key, value)
     }


### PR DESCRIPTION
Key in scala should always be represented as an Option[Key].

Updated the helper methods to reflect this.