### PR TITLE
Catch exceptions thrown by the send and turn into failed future

### DIFF
--- a/client/src/main/scala/cakesolutions/kafka/KafkaProducer.scala
+++ b/client/src/main/scala/cakesolutions/kafka/KafkaProducer.scala
@@ -10,6 +10,7 @@ import org.apache.kafka.common.serialization.Serializer
 
 import scala.collection.JavaConversions._
 import scala.concurrent.{Future, Promise}
+import scala.util.control.NonFatal
 import scala.util.{Failure, Success, Try}
 
 /**
@@ -151,11 +152,10 @@ final class KafkaProducer[K, V](val producer: JKafkaProducer[K, V]) {
     */
   def send(record: ProducerRecord[K, V]): Future[RecordMetadata] = {
     val promise = Promise[RecordMetadata]()
-    Try {
+    try {
       producer.send(record, producerCallback(promise))
-    } match {
-      case Failure(e: Exception) => promise.failure(e)
-      case x => x
+    } catch {
+      case NonFatal(e) => promise.failure(e)
     }
 
     promise.future

--- a/client/src/main/scala/cakesolutions/kafka/KafkaProducer.scala
+++ b/client/src/main/scala/cakesolutions/kafka/KafkaProducer.scala
@@ -1,5 +1,7 @@
 package cakesolutions.kafka
 
+import java.lang.Exception
+
 import cakesolutions.kafka.TypesafeConfigExtensions._
 import com.typesafe.config.Config
 import org.apache.kafka.clients.producer.{Callback, ProducerConfig, ProducerRecord, RecordMetadata, KafkaProducer => JKafkaProducer}
@@ -149,7 +151,13 @@ final class KafkaProducer[K, V](val producer: JKafkaProducer[K, V]) {
     */
   def send(record: ProducerRecord[K, V]): Future[RecordMetadata] = {
     val promise = Promise[RecordMetadata]()
-    producer.send(record, producerCallback(promise))
+    Try {
+      producer.send(record, producerCallback(promise))
+    } match {
+      case Failure(e: Exception) => promise.failure(e)
+      case x => x
+    }
+
     promise.future
   }
 


### PR DESCRIPTION
While working with the java `KafkaProducer`, I encountered an error where an `Exception` could be thrown within the `send`. This would cause the callback not to get called and the failed `Future` to not be created. I thought the fix might be useful here as well, let me know your thoughts. 