### PR TITLE
Replace mutable Seq/Iterable with immutable collections

### DIFF
--- a/akka/src/it/scala/cakesolutions/kafka/akka/KafkaConsumerActorPerfSpec.scala
+++ b/akka/src/it/scala/cakesolutions/kafka/akka/KafkaConsumerActorPerfSpec.scala
@@ -73,7 +73,7 @@ class KafkaConsumerActorPerfSpec(system_ : ActorSystem)
     producer.flush()
     log.info("Delivered {} messages to topic {}", totalMessages, topic)
 
-    consumer.subscribe(AutoPartition(Seq(topic)))
+    consumer.subscribe(AutoPartition(List(topic)))
 
     whenReady(pilot.future) { case (totalTime, messagesPerSec) =>
       log.info("Total Time millis : {}", totalTime)

--- a/akka/src/it/scala/cakesolutions/kafka/akka/KafkaE2EActorPerfSpec.scala
+++ b/akka/src/it/scala/cakesolutions/kafka/akka/KafkaE2EActorPerfSpec.scala
@@ -78,7 +78,7 @@ class KafkaE2EActorPerfSpec(system_ : ActorSystem)
     testProducer.flush()
     log.info("Delivered {} messages to topic {}", totalMessages, sourceTopic)
 
-    consumer.subscribe(AutoPartition(Seq(sourceTopic)))
+    consumer.subscribe(AutoPartition(List(sourceTopic)))
 
     whenReady(pilot.future) { case (totalTime, messagesPerSec) =>
       log.info("Total Time millis : {}", totalTime)

--- a/akka/src/main/scala/cakesolutions/kafka/akka/KafkaConsumerActor.scala
+++ b/akka/src/main/scala/cakesolutions/kafka/akka/KafkaConsumerActor.scala
@@ -12,6 +12,7 @@ import org.apache.kafka.common.errors.WakeupException
 import org.apache.kafka.common.serialization.Deserializer
 
 import scala.collection.JavaConverters._
+import scala.collection.immutable.Iterable
 import scala.concurrent.duration._
 import scala.reflect.runtime.universe.TypeTag
 import scala.util.{Failure, Success, Try}

--- a/akka/src/main/scala/cakesolutions/kafka/akka/KafkaProducerActor.scala
+++ b/akka/src/main/scala/cakesolutions/kafka/akka/KafkaProducerActor.scala
@@ -6,6 +6,7 @@ import com.typesafe.config.Config
 import org.apache.kafka.clients.producer.{ProducerRecord, RecordMetadata}
 import org.apache.kafka.common.serialization.Serializer
 
+import scala.collection.immutable.Iterable
 import scala.concurrent.Future
 import scala.reflect.runtime.universe.TypeTag
 import scala.util.{Failure, Success}

--- a/akka/src/main/scala/cakesolutions/kafka/akka/ProducerRecords.scala
+++ b/akka/src/main/scala/cakesolutions/kafka/akka/ProducerRecords.scala
@@ -3,6 +3,7 @@ package cakesolutions.kafka.akka
 import cakesolutions.kafka.KafkaProducerRecord
 import org.apache.kafka.clients.producer.ProducerRecord
 
+import scala.collection.immutable.Seq
 import scala.reflect.runtime.universe.TypeTag
 
 /**
@@ -150,7 +151,7 @@ object ProducerRecords {
   * @param failureResponse optional message that is to be sent back to the sender when messages were not successfully written to Kafka
   */
 final case class ProducerRecords[Key: TypeTag, Value: TypeTag](
-  records: Iterable[ProducerRecord[Key, Value]],
+  records: Seq[ProducerRecord[Key, Value]],
   successResponse: Option[Any] = None,
   failureResponse: Option[Any] = None
 ) extends TypeTagged[ProducerRecords[Key, Value]]

--- a/akka/src/test/scala/cakesolutions/kafka/akka/ConsumerRecordsSpec.scala
+++ b/akka/src/test/scala/cakesolutions/kafka/akka/ConsumerRecordsSpec.scala
@@ -6,7 +6,7 @@ import org.scalatest.{FlatSpecLike, Inside, Matchers}
 class ConsumerRecordsSpec extends FlatSpecLike with Matchers with Inside {
 
   val partition = KafkaTopicPartition("sometopic", 0)
-  val knownInput: ConsumerRecords[String, Int] = ConsumerRecords.fromPairs(partition, Seq(Some("foo") -> 1))
+  val knownInput: ConsumerRecords[String, Int] = ConsumerRecords.fromPairs(partition, List(Some("foo") -> 1))
   val partiallyKnownInput: ConsumerRecords[_, _] = knownInput
   val anyInput: Any = knownInput
 

--- a/akka/src/test/scala/cakesolutions/kafka/akka/KafkaConsumerActorSpec.scala
+++ b/akka/src/test/scala/cakesolutions/kafka/akka/KafkaConsumerActorSpec.scala
@@ -80,7 +80,7 @@ class KafkaConsumerActorSpec(system_ : ActorSystem) extends KafkaIntSpec(system_
           producer.flush()
 
           val consumer = KafkaConsumerActor(consumerConfig, actorConf, testActor)
-          consumer.subscribe(AutoPartition(Seq(topic)))
+          consumer.subscribe(AutoPartition(List(topic)))
 
           val rs = expectMsgClass(30.seconds, classOf[ConsumerRecords[String, String]])
           consumer.confirm(rs.offsets)
@@ -181,9 +181,11 @@ class KafkaConsumerActorSpec(system_ : ActorSystem) extends KafkaIntSpec(system_
     producer.flush()
 
     val consumer = system.actorOf(KafkaConsumerActor.props(consumerConf, KafkaConsumerActor.Conf(), testActor))
-    consumer ! Subscribe.AutoPartitionWithManualOffset(Seq(topic),
-      tps => Offsets(tps.map { tp => tp -> 0l }.toMap),
-      _ => ())
+    consumer ! Subscribe.AutoPartitionWithManualOffset(
+      topics = List(topic),
+      assignedListener = tps => Offsets(tps.map { tp => tp -> 0l }.toMap),
+      revokedListener = _ => ()
+    )
 
     val rs = expectMsgClass(30.seconds, classOf[ConsumerRecords[String, String]])
     consumer ! Confirm(rs.offsets)

--- a/akka/src/test/scala/cakesolutions/kafka/akka/KafkaProducerActorSpec.scala
+++ b/akka/src/test/scala/cakesolutions/kafka/akka/KafkaProducerActorSpec.scala
@@ -31,10 +31,11 @@ class KafkaProducerActorSpec(system_ : ActorSystem) extends KafkaIntSpec(system_
     val topic = randomString
     val probe = TestProbe()
     val producer = system.actorOf(KafkaProducerActor.props(producerConf))
-    val batch: Seq[ProducerRecord[String, String]] = Seq(
+    val batch: List[ProducerRecord[String, String]] = List(
       KafkaProducerRecord(topic, "foo"),
       KafkaProducerRecord(topic, "key", "value"),
-      KafkaProducerRecord(topic, "bar"))
+      KafkaProducerRecord(topic, "bar")
+    )
     val message = ProducerRecords(batch, Some('response))
 
     probe.send(producer, message)
@@ -54,7 +55,7 @@ class KafkaProducerActorSpec(system_ : ActorSystem) extends KafkaIntSpec(system_
     val topic = randomString
     val probe = TestProbe()
     val producer = system.actorOf(KafkaProducerActor.props(producerConf))
-    val batch: Seq[ProducerRecord[String, String]] = Seq(
+    val batch: List[ProducerRecord[String, String]] = List(
       KafkaProducerRecord(topic, "foo"),
       KafkaProducerRecord(topic, "key", "value"),
       KafkaProducerRecord(topic, "bar")

--- a/client/src/main/scala/cakesolutions/kafka/KafkaProducerRecord.scala
+++ b/client/src/main/scala/cakesolutions/kafka/KafkaProducerRecord.scala
@@ -3,6 +3,7 @@ package cakesolutions.kafka
 import cakesolutions.kafka.KafkaTopicPartition.{Partition, Topic}
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.TopicPartition
+import scala.collection.immutable.Seq
 
 /**
   * Helper functions for creating Kafka's `ProducerRecord`s.
@@ -158,7 +159,7 @@ object KafkaProducerRecord {
     *
     * @param keyValuesWithTopic a sequence of topic, key, and value triples.
     */
-  def fromKeyValuesWithTopic[Key, Value](keyValuesWithTopic: Iterable[(String, Option[Key], Value)]): Iterable[ProducerRecord[Key, Value]] =
+  def fromKeyValuesWithTopic[Key, Value](keyValuesWithTopic: Seq[(String, Option[Key], Value)]): Seq[ProducerRecord[Key, Value]] =
     keyValuesWithTopic.map {
       case (topic, key, value) => KafkaProducerRecord(topic, key, value)
     }

--- a/examples/src/main/scala/cakesolutions/kafka/examples/AutoPartitionConsumer.scala
+++ b/examples/src/main/scala/cakesolutions/kafka/examples/AutoPartitionConsumer.scala
@@ -46,11 +46,12 @@ object AutoPartitionConsumer {
 
 class AutoPartitionConsumer(
   kafkaConfig: KafkaConsumer.Conf[String, String],
-  actorConfig: KafkaConsumerActor.Conf) extends Actor with ActorLogging {
+  actorConfig: KafkaConsumerActor.Conf
+) extends Actor with ActorLogging {
 
-  val recordsExt = ConsumerRecords.extractor[String, String]
+  private val recordsExt = ConsumerRecords.extractor[String, String]
 
-  val consumer = context.actorOf(
+  private val consumer = context.actorOf(
     KafkaConsumerActor.props(kafkaConfig, actorConfig, self)
   )
   context.watch(consumer)

--- a/testkit/src/main/scala/cakesolutions.kafka/testkit/KafkaServer.scala
+++ b/testkit/src/main/scala/cakesolutions.kafka/testkit/KafkaServer.scala
@@ -12,6 +12,7 @@ import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
+import scala.collection.immutable.{Iterable, Seq}
 import scala.util.{Random, Try}
 
 object KafkaServer {
@@ -165,7 +166,7 @@ final class KafkaServer(
         sys.error(s"Did not receive expected amount records. Expected $expectedNumOfRecords but got ${collected.size}.")
       }
 
-      collected.toVector
+      collected.toList
     } finally {
       consumer.close()
     }


### PR DESCRIPTION
The `Seq` and `Iterable` collections from predef can either be mutable or immutable. Replacing them with immutable alternatives.