### PR TITLE
Allow the offsetsForTimes functionality in the Akka client

### DIFF
--- a/akka/src/main/scala/cakesolutions/kafka/akka/KafkaConsumerActor.scala
+++ b/akka/src/main/scala/cakesolutions/kafka/akka/KafkaConsumerActor.scala
@@ -13,8 +13,10 @@ import org.apache.kafka.common.serialization.Deserializer
 
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
+import scala.language.implicitConversions
 import scala.reflect.runtime.universe.TypeTag
 import scala.util.{Failure, Success, Try}
+
 
 /**
   * An actor that wraps [[KafkaConsumer]].
@@ -151,6 +153,21 @@ object KafkaConsumerActor {
       * @param offsets the topics with partitions and offsets to start consuming from
       */
     final case class ManualOffset(offsets: Offsets) extends Subscribe
+
+    /**
+      * Subscribe to topics by providing a timestamp per partition denoting the point in time with the first offset that must be retrieved.
+      *
+      * In manually assigned partition mode, the consumer will specify the partitions directly,
+      * This means that Kafka will not be automatically rebalance the partitions when new consumers appear in the consumer group.
+      *
+      * In addition to manually assigning the partitions, the partition offsets will be set to start from the given offsets.
+      *
+      * The client should ensure that received records are confirmed with 'commit = false' to ensure consumed records are
+      * not committed back to kafka.
+      *
+      * @param offsets the topics with partitions and timestamps to start consuming from
+      */
+    final case class ManualOffsetForTimes(offsets: Offsets) extends Subscribe
   }
 
   /**
@@ -365,6 +382,14 @@ private final class KafkaConsumerActorImpl[K: TypeTag, V: TypeTag](
   import PollScheduling.Poll
   import context.become
 
+  /**
+    * Implicit conversion to support calling the org.apache.kafka.clients.consumer.KafkaConsumer.offsetsForTimes method with a Map[TopicPartition, scala.Long].
+    */
+  implicit def toJavaOffsetQuery(offsetQuery: Map[TopicPartition, scala.Long]): java.util.Map[TopicPartition, java.lang.Long] =
+    offsetQuery
+      .map { case (tp, time) => tp -> new java.lang.Long(time) }
+      .asJava
+
   type Records = ConsumerRecords[K, V]
 
   private val consumer = KafkaConsumer[K, V](consumerConf)
@@ -391,9 +416,19 @@ private final class KafkaConsumerActorImpl[K: TypeTag, V: TypeTag](
           Subscribe.AutoPartitionWithManualOffset(s.topics, s.assignedListener, s.revokedListener)
         case _: Subscribe.ManualPartition => Subscribe.ManualOffset(offsets)
         case _: Subscribe.ManualOffset => Subscribe.ManualOffset(offsets)
+        case _: Subscribe.ManualOffsetForTimes =>
+          val timeOffsets = timeOffsets2regularOffsets(offsets)
+          Subscribe.ManualOffset(timeOffsets)
       }
       lastConfirmedOffsets.map(advance).getOrElse(subscription)
     }
+  }
+
+  private def timeOffsets2regularOffsets(timeOffsets: Offsets) : Offsets = {
+    import scala.collection.JavaConverters._
+    val javaOffsetsAndTimestamps = consumer.offsetsForTimes(timeOffsets.offsetsMap).asScala.toMap
+    val offsets = javaOffsetsAndTimestamps.mapValues(_.offset())
+    Offsets(offsets)
   }
 
   private case class Subscribed(
@@ -676,6 +711,12 @@ private final class KafkaConsumerActorImpl[K: TypeTag, V: TypeTag](
       log.info("Subscribing in manual partition assignment mode to partitions with offsets [{}]", offsets)
       consumer.assign(offsets.topicPartitions.toList.asJava)
       seekOffsets(offsets)
+
+    case Subscribe.ManualOffsetForTimes(offsets) =>
+      log.info("Subscribing in manual partition assignment mode with timestamps to partitions with offsets [{}]", offsets)
+      consumer.assign(offsets.topicPartitions.toList.asJava)
+      val regularOffsets = timeOffsets2regularOffsets(offsets)
+      seekOffsets(regularOffsets)
   }
 
   // The client is usually misusing the Consumer if incorrect Confirm offsets are provided


### PR DESCRIPTION
This PR creates a new Subscribe message for the Akka Client to be able to also provide offsets when requested by timestamp.