### PR TITLE
Add support to call configure method of serializer/deserializers 

### DIFF
--- a/client/src/main/scala/cakesolutions/kafka/KafkaConsumer.scala
+++ b/client/src/main/scala/cakesolutions/kafka/KafkaConsumer.scala
@@ -144,6 +144,9 @@ object KafkaConsumer {
     * @tparam V value serialiser type
     * @return Kafka consumer client
     */
-  def apply[K, V](conf: Conf[K, V]): JKafkaConsumer[K, V] =
+  def apply[K, V](conf: Conf[K, V]): JKafkaConsumer[K, V] = {
+    conf.keyDeserializer.configure(conf.props.asJava, true)
+    conf.valueDeserializer.configure(conf.props.asJava, false)
     new JKafkaConsumer[K, V](conf.props.asJava, conf.keyDeserializer, conf.valueDeserializer)
+  }
 }

--- a/client/src/main/scala/cakesolutions/kafka/KafkaProducer.scala
+++ b/client/src/main/scala/cakesolutions/kafka/KafkaProducer.scala
@@ -216,8 +216,11 @@ object KafkaProducer {
     * @tparam V type of the value that the producer accepts
     * @return Kafka producer instance
     */
-  def apply[K, V](conf: Conf[K, V]): KafkaProducer[K, V] =
+  def apply[K, V](conf: Conf[K, V]): KafkaProducer[K, V] = {
+    conf.keySerializer.configure(conf.props.asJava, true)
+    conf.valueSerializer.configure(conf.props.asJava, false)
     apply(new JKafkaProducer[K, V](conf.props.asJava, conf.keySerializer, conf.valueSerializer))
+  }
 
   /**
     * Create [[KafkaProducer]] from a given Java `KafkaProducer` object.

--- a/client/src/test/scala/cakesolutions/kafka/ConfigureSerializationSpec.scala
+++ b/client/src/test/scala/cakesolutions/kafka/ConfigureSerializationSpec.scala
@@ -1,0 +1,76 @@
+package cakesolutions.kafka
+
+import java.util
+import com.typesafe.config.ConfigFactory
+import org.apache.kafka.common.serialization.{Deserializer, Serializer}
+
+class ConfigureSerializationSpec extends KafkaIntSpec{
+
+  private class MockDeserializer() extends Deserializer[String] {
+    var configuration: String = _
+    var isKeyDeserializer: Boolean = _
+
+    override def configure(configs: util.Map[String, _], isKey: Boolean): Unit = {
+      configuration = configs.get("mock.config").toString
+      isKeyDeserializer = isKey
+    }
+
+    override def close(): Unit = { }
+
+    override def deserialize(topic: String, data: Array[Byte]): String = new String(data)
+  }
+
+  private class MockSerializer() extends Serializer[String] {
+    var configuration: String = _
+    var isKeySerializer: Boolean = _
+
+    override def configure(configs: util.Map[String, _], isKey: Boolean): Unit = {
+      configuration = configs.get("mock.config").toString
+      isKeySerializer = isKey
+    }
+
+    override def serialize(topic: String, data: String): Array[Byte] = data.getBytes
+
+    override def close(): Unit = { }
+  }
+
+  "Producer" should "configure the serializers" in {
+    val keySerializer = new MockSerializer
+    val valueSerializer = new MockSerializer
+
+    val conf = KafkaProducer.Conf(
+      ConfigFactory.parseString(
+        s"""
+           | bootstrap.servers = "localhost:$kafkaPort",
+           | mock.config = "mock_value"
+         """.stripMargin
+      ), keySerializer, valueSerializer)
+
+    val _ = KafkaProducer(conf)
+
+    keySerializer.configuration shouldEqual "mock_value"
+    keySerializer.isKeySerializer shouldEqual true
+    valueSerializer.configuration shouldEqual "mock_value"
+    valueSerializer.isKeySerializer shouldEqual false
+  }
+
+  "Consumer" should "configure the deserializers" in {
+    val keyDeserializer = new MockDeserializer
+    val valueDeserializer = new MockDeserializer
+
+    val conf = KafkaConsumer.Conf(
+      ConfigFactory.parseString(
+        s"""
+           | bootstrap.servers = "localhost:$kafkaPort",
+           | mock.config = "mock_value"
+         """.stripMargin
+      ), keyDeserializer, valueDeserializer)
+
+    val _ = KafkaConsumer(conf)
+
+    keyDeserializer.configuration shouldEqual "mock_value"
+    keyDeserializer.isKeyDeserializer shouldEqual true
+    valueDeserializer.configuration shouldEqual "mock_value"
+    valueDeserializer.isKeyDeserializer shouldEqual false
+  }
+}


### PR DESCRIPTION
Currently when the serializers and deserializers are passed into KafkaProducer and KafkaConsumer, the configure method of Serializer interface is not called on them automatically as opposed to the case when they are passed in as config parameters. Since the Scala wrapper in this library requires you to instantiate the serializers and deserializers, this puts the onus the client to do this. The most known example of this is the KafkaAvroSerializer/Deserializers where configure is required to setup the schema registry server. But if you try to call the configure method before passing into KafkaProducer/Consumer, the client needs to copy&paste TypeSafeConfigExtensions which is a private object in this library to their own project.

This pull request proposes to simply call the configure method (hopefully idempotent for all serializer/deserializer implementations) in the KafkaProducer/Consumer implementation.

Another option could be making the TypeSafeConfigExtensions public, if this pull-request is not preferred.