### PR TITLE
Remove unused parameter

### DIFF
--- a/testkit/src/main/scala/cakesolutions.kafka/testkit/KafkaServer.scala
+++ b/testkit/src/main/scala/cakesolutions.kafka/testkit/KafkaServer.scala
@@ -187,7 +187,6 @@ final class KafkaServer(
     * @param producerConfig custom configurations for Kafka producer
     */
   def produce[Key, Value](
-    topic: String,
     records: Iterable[ProducerRecord[Key, Value]],
     keySerializer: Serializer[Key],
     valueSerializer: Serializer[Value],


### PR DESCRIPTION
`topic` is not required whatsoever in the `produce` method and hints the user to a possible implementation detail that it is not used.